### PR TITLE
[MTDSA-11202] Adding new allowance examples to Annual Summary RAML

### DIFF
--- a/resources/public/api/conf/1.0/endpoints/createAndAmendAnnualSummary.raml
+++ b/resources/public/api/conf/1.0/endpoints/createAndAmendAnnualSummary.raml
@@ -22,7 +22,10 @@ body:
     examples:
      example-1:
       description: Create and Amend Self-Employment Annual Summary Request
-      value: !include ../examples/create_and_amend_annual_summary_request.json
+      value: !include ../examples/create_and_amend_annual_summary_other_allowances_request.json
+     example-2:
+      description: Create and Amend Self-Employment Annual Summary Request with Trading Allowance
+      value: !include ../examples/create_and_amend_annual_summary_tradingAllowance_request.json_request.json
 responses:
   200:
     body:

--- a/resources/public/api/conf/1.0/endpoints/createAndAmendAnnualSummary.raml
+++ b/resources/public/api/conf/1.0/endpoints/createAndAmendAnnualSummary.raml
@@ -25,7 +25,7 @@ body:
       value: !include ../examples/create_and_amend_annual_summary_other_allowances_request.json
      example-2:
       description: Create and Amend Self-Employment Annual Summary Request with Trading Allowance
-      value: !include ../examples/create_and_amend_annual_summary_tradingAllowance_request.json_request.json
+      value: !include ../examples/create_and_amend_annual_summary_trading_allowance_request.json
 responses:
   200:
     body:

--- a/resources/public/api/conf/1.0/endpoints/retrieveAnnualSummary.raml
+++ b/resources/public/api/conf/1.0/endpoints/retrieveAnnualSummary.raml
@@ -22,4 +22,10 @@ responses:
     body:
       application/json:
         type: !include ../schemas/retrieve_annual_summary_response.json
-        example: !include ../examples/retrieve_annual_summary_response.json
+        examples:
+          example-1:
+            description: Example Response
+            value: !include ../examples/retrieve_annual_summary_other_allowances_response.json
+          example-2:
+            description: Example Response with Trading Allowance
+            value: !include ../examples/retrieve_annual_summary_trading_allowance_response.json

--- a/resources/public/api/conf/1.0/examples/create_and_amend_annual_summary_other_allowances_request.json
+++ b/resources/public/api/conf/1.0/examples/create_and_amend_annual_summary_other_allowances_request.json
@@ -1,0 +1,30 @@
+{
+  "adjustments": {
+    "includedNonTaxableProfits": 216.12,
+    "basisAdjustment": 626.53,
+    "overlapReliefUsed": 153.89,
+    "accountingAdjustment": 514.24,
+    "averagingAdjustment": 124.98,
+    "lossBroughtForward": 571.27,
+    "outstandingBusinessIncome": 751.03,
+    "balancingChargeBPRA": 719.23,
+    "balancingChargeOther": 956.47,
+    "goodsAndServicesOwnUse": 157.43
+  },
+  "allowances": {
+    "annualInvestmentAllowance": 561.32,
+    "businessPremisesRenovationAllowance": 198.45,
+    "capitalAllowanceMainPool": 825.34,
+    "capitalAllowanceSpecialRatePool": 647.12,
+    "zeroEmissionGoodsVehicleAllowance": 173.64,
+    "enhancedCapitalAllowance": 115.98,
+    "allowanceOnSales": 548.15,
+    "capitalAllowanceSingleAssetPool": 901.67,
+    "electricChargePointAllowance": 143.94
+  },
+  "nonFinancials": {
+    "class4NicInfo":{
+      "exemptionCode": "002 - Trustee"
+    }
+  }
+}

--- a/resources/public/api/conf/1.0/examples/create_and_amend_annual_summary_trading_allowance_request.json
+++ b/resources/public/api/conf/1.0/examples/create_and_amend_annual_summary_trading_allowance_request.json
@@ -12,16 +12,7 @@
     "goodsAndServicesOwnUse": 157.43
   },
   "allowances": {
-    "annualInvestmentAllowance": 561.32,
-    "businessPremisesRenovationAllowance": 198.45,
-    "capitalAllowanceMainPool": 825.34,
-    "capitalAllowanceSpecialRatePool": 647.12,
-    "zeroEmissionGoodsVehicleAllowance": 173.64,
-    "enhancedCapitalAllowance": 115.98,
-    "allowanceOnSales": 548.15,
-    "capitalAllowanceSingleAssetPool": 901.67,
-    "tradingAllowance": 521.34,
-    "electricChargePointAllowance": 143.94
+    "tradingAllowance": 521.34
   },
   "nonFinancials": {
     "class4NicInfo":{

--- a/resources/public/api/conf/1.0/examples/retrieve_annual_summary_other_allowances_response.json
+++ b/resources/public/api/conf/1.0/examples/retrieve_annual_summary_other_allowances_response.json
@@ -1,0 +1,46 @@
+{
+  "adjustments": {
+    "includedNonTaxableProfits": 3123.15,
+    "basisAdjustment": 192.25,
+    "overlapReliefUsed": 399.00,
+    "accountingAdjustment": 31.25,
+    "averagingAdjustment": 3134.20,
+    "lossBroughtForward": 10.89,
+    "outstandingBusinessIncome": 102.10,
+    "balancingChargeBPRA": 40.30,
+    "balancingChargeOther": 3992.00,
+    "goodsAndServicesOwnUse": 391.25
+  },
+  "allowances": {
+    "annualInvestmentAllowance": 3992.10,
+    "capitalAllowanceMainPool": 20.11,
+    "capitalAllowanceSpecialRatePool": 29.00,
+    "zeroEmissionGoodsVehicleAllowance": 500.00,
+    "businessPremisesRenovationAllowance": 31.00,
+    "enhancedCapitalAllowance": 49.19,
+    "allowanceOnSales": 39.48,
+    "capitalAllowanceSingleAssetPool": 32.39
+  },
+  "nonFinancials": {
+    "class4NicInfo": {
+      "exemptionCode": "002 - Trustee"
+    }
+  },
+  "links": [
+    {
+      "href": "/individuals/business/self-employment/TC663795B/XAIS12345678910/annual/2019-20",
+      "rel": "create-and-amend-self-employment-annual-summary",
+      "method": "PUT"
+    },
+    {
+      "href": "/individuals/business/self-employment/TC663795B/XAIS12345678910/annual/2019-20",
+      "rel": "self",
+      "method": "GET"
+    },
+    {
+      "href": "/individuals/business/self-employment/TC663795B/XAIS12345678910/annual/2019-20",
+      "rel": "delete-self-employment-annual-summary",
+      "method": "DELETE"
+    }
+  ]
+}

--- a/resources/public/api/conf/1.0/examples/retrieve_annual_summary_trading_allowance_response.json
+++ b/resources/public/api/conf/1.0/examples/retrieve_annual_summary_trading_allowance_response.json
@@ -12,14 +12,6 @@
     "goodsAndServicesOwnUse": 391.25
   },
   "allowances": {
-    "annualInvestmentAllowance": 3992.10,
-    "capitalAllowanceMainPool": 20.11,
-    "capitalAllowanceSpecialRatePool": 29.00,
-    "zeroEmissionGoodsVehicleAllowance": 500.00,
-    "businessPremisesRenovationAllowance": 31.00,
-    "enhancedCapitalAllowance": 49.19,
-    "allowanceOnSales": 39.48,
-    "capitalAllowanceSingleAssetPool": 32.39,
     "tradingAllowance": 85.39
   },
   "nonFinancials": {


### PR DESCRIPTION
- including new examples to account for `tradingAllowance` not being allowed with other allowances