### PR TITLE
[MTDSA-35221]: Add FYA optional field to TY26-27 schema

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -132,6 +132,11 @@ feature-switch {
     enabled = true
     released-in-production = false
   }
+  
+  r22_fya_docs {
+    enabled = true
+    released-in-production = false
+  }
 
   supporting-agents-access-control {
     enabled = true

--- a/resources/public/api/conf/5.0/examples/retrieveAnnualSubmission/def4/full_response.json
+++ b/resources/public/api/conf/5.0/examples/retrieveAnnualSubmission/def4/full_response.json
@@ -20,6 +20,9 @@
     "allowanceOnSales": 678.99,
     "capitalAllowanceSingleAssetPool": 563.89,
     "zeroEmissionsCarAllowance": 678.78,
+    {{#if (enabled 'r22_fya_docs')}}
+      "firstYearAllowanceOnPlantAndMachinery": 678.78,
+    {{/if}}
     "structuredBuildingAllowance": [
       {
         "amount": 564.89,

--- a/resources/public/api/conf/5.0/schemas/retrieveAnnualSubmission/def4/response.json
+++ b/resources/public/api/conf/5.0/schemas/retrieveAnnualSubmission/def4/response.json
@@ -168,6 +168,16 @@
           "maximum": 99999999999.99,
           "example": 2000.99
         },
+        {{#if (enabled 'r22_fya_docs')}}
+          "firstYearAllowanceOnPlantAndMachinery": {
+            "description": "{{#unless (releasedInProduction 'r22_fya_docs')}}[Test only] {{/unless}} First-Year Allowance for qualifying expenditure incurred on plant and machinery. The value must be between 0 and 99999999999.99 up to 2 decimal places.",
+            "type": "number",
+            "multipleOf": 0.01,
+            "minimum": 0,
+            "maximum": 99999999999.99,
+            "example": 2000.99
+          },
+        {{/if}}
         "tradingIncomeAllowance": {
           "description": "The amount of trading allowance (can not be supplied with any other allowances). The value must be between 0 and 1000.00 up to 2 decimal places.",
           "type": "number",


### PR DESCRIPTION
### Docs Not Enabled + Not Released in Prod:

```
  r22_fya_docs {
    enabled = false
    released-in-production = false
  }
```

<img width="1946" height="1102" alt="docs-not-enabled" src="https://github.com/user-attachments/assets/5a66c01e-1253-4961-9999-a5ea4ab756a8" />

---

### Docs Enabled + Not Released in Prod:

```
  r22_fya_docs {
    enabled = true
    released-in-production = false
  }
```

<img width="2025" height="1115" alt="docs-enabled-no-prod" src="https://github.com/user-attachments/assets/1670879f-9ea5-46c4-8c58-3771a22c2c8c" />

---

### Docs Enabled + Released in Prod:

```
  r22_fya_docs {
    enabled = true
    released-in-production = true
  }
```

<img width="2024" height="1117" alt="docs-enabled-with-prod" src="https://github.com/user-attachments/assets/cf14604e-640d-43c8-bbf9-e014091eebbd" />
