### PR TITLE
[MTDSA-35278]: add FYA optional field for TY26-27

### DIFF
--- a/app/v5/retrieveAnnualSubmission/def4/model/response/RetrieveAllowances.scala
+++ b/app/v5/retrieveAnnualSubmission/def4/model/response/RetrieveAllowances.scala
@@ -29,6 +29,7 @@ case class RetrieveAllowances(
     capitalAllowanceSingleAssetPool: Option[BigDecimal],
     tradingIncomeAllowance: Option[BigDecimal],
     zeroEmissionsCarAllowance: Option[BigDecimal],
+    firstYearAllowanceOnPlantAndMachinery: Option[BigDecimal],
     structuredBuildingAllowance: Option[Seq[RetrieveStructuredBuildingAllowance]],
     enhancedStructuredBuildingAllowance: Option[Seq[RetrieveStructuredBuildingAllowance]]
 )
@@ -45,6 +46,7 @@ object RetrieveAllowances {
       (JsPath \ "capitalAllowanceSingleAssetPool").readNullable[BigDecimal] and
       (JsPath \ "tradingIncomeAllowance").readNullable[BigDecimal] and
       (JsPath \ "zeroEmissionsCarAllowance").readNullable[BigDecimal] and
+      (JsPath \ "firstYearAllowanceOnPlantAndMachinery").readNullable[BigDecimal] and
       (JsPath \ "structuredBuildingAllowance").readNullable[Seq[RetrieveStructuredBuildingAllowance]] and
       (JsPath \ "enhancedStructuredBuildingAllowance").readNullable[Seq[RetrieveStructuredBuildingAllowance]]
   )(RetrieveAllowances.apply)

--- a/test/v5/retrieveAnnualSubmission/def4/model/Def4_RetrieveAnnualSubmissionFixture.scala
+++ b/test/v5/retrieveAnnualSubmission/def4/model/Def4_RetrieveAnnualSubmissionFixture.scala
@@ -143,6 +143,7 @@ trait Def4_RetrieveAnnualSubmissionFixture {
     capitalAllowanceSingleAssetPool = Some(8.12),
     tradingIncomeAllowance = None,
     zeroEmissionsCarAllowance = Some(11.12),
+    firstYearAllowanceOnPlantAndMachinery = Some(12.12),
     structuredBuildingAllowance = Some(List(structuredBuildingAllowance)),
     enhancedStructuredBuildingAllowance = Some(List(structuredBuildingAllowance))
   )
@@ -156,6 +157,7 @@ trait Def4_RetrieveAnnualSubmissionFixture {
        |  "allowanceOnSales": 7.12,
        |  "capitalAllowanceSingleAssetPool": 8.12,
        |  "zeroEmissionsCarAllowance": 11.12,
+       |  "firstYearAllowanceOnPlantAndMachinery": 12.12,
        |  "structuredBuildingAllowance": [ $structuredBuildingAllowanceMtdJson ],
        |  "enhancedStructuredBuildingAllowance": [ $structuredBuildingAllowanceMtdJson ]
        |}
@@ -170,6 +172,7 @@ trait Def4_RetrieveAnnualSubmissionFixture {
        |  "allowanceOnSales": 7.12,
        |  "capitalAllowanceSingleAssetPool": 8.12,
        |  "zeroEmissionsCarAllowance": 11.12,
+       |  "firstYearAllowanceOnPlantAndMachinery": 12.12,
        |  "structuredBuildingAllowance": [ $structuredBuildingAllowanceDownstreamJson ],
        |  "enhancedStructuredBuildingAllowance": [ $structuredBuildingAllowanceDownstreamJson]
        |}

--- a/test/v5/retrieveAnnualSubmission/def4/model/response/Def4_RetrieveAnnualSubmissionResponseSpec.scala
+++ b/test/v5/retrieveAnnualSubmission/def4/model/response/Def4_RetrieveAnnualSubmissionResponseSpec.scala
@@ -23,7 +23,7 @@ import v5.retrieveAnnualSubmission.def4.model.Def4_RetrieveAnnualSubmissionFixtu
 class Def4_RetrieveAnnualSubmissionResponseSpec extends UnitSpec with Def4_RetrieveAnnualSubmissionFixture {
 
   private val retrieveAnnualSubmissionResponse = Def4_RetrieveAnnualSubmissionResponse(
-    allowances = Some(RetrieveAllowances(None, None, None, None, None, None, None, None, None, None, None)),
+    allowances = Some(RetrieveAllowances(None, None, None, None, None, None, None, None, None, None, None, None)),
     adjustments = Some(RetrieveAdjustments(None, None, None, None, None, None, None, None, None, None)),
     nonFinancials = Some(RetrieveNonFinancials(businessDetailsChangedRecently = true, None))
   )

--- a/test/v5/retrieveAnnualSubmission/def4/model/response/RetrieveAllowancesSpec.scala
+++ b/test/v5/retrieveAnnualSubmission/def4/model/response/RetrieveAllowancesSpec.scala
@@ -31,6 +31,7 @@ class RetrieveAllowancesSpec extends UnitSpec {
     capitalAllowanceSingleAssetPool = Some(8.12),
     tradingIncomeAllowance = Some(10.12),
     zeroEmissionsCarAllowance = Some(11.12),
+    firstYearAllowanceOnPlantAndMachinery = Some(12.12),
     structuredBuildingAllowance = Some(Nil),
     enhancedStructuredBuildingAllowance = Some(Nil)
   )
@@ -49,6 +50,7 @@ class RetrieveAllowancesSpec extends UnitSpec {
              |  "capitalAllowanceSingleAssetPool": 8.12,
              |  "tradingIncomeAllowance": 10.12,
              |  "zeroEmissionsCarAllowance": 11.12,
+             |  "firstYearAllowanceOnPlantAndMachinery": 12.12,
              |  "structuredBuildingAllowance": [],
              |  "enhancedStructuredBuildingAllowance": []
              |}
@@ -74,6 +76,7 @@ class RetrieveAllowancesSpec extends UnitSpec {
              |  "capitalAllowanceSingleAssetPool": 8.12,
              |  "tradingIncomeAllowance": 10.12,
              |  "zeroEmissionsCarAllowance": 11.12,
+             |  "firstYearAllowanceOnPlantAndMachinery": 12.12,
              |  "structuredBuildingAllowance": [],
              |  "enhancedStructuredBuildingAllowance": []
              |}


### PR DESCRIPTION
## Bruno test against the Implementation + Stub:


### TY 2026-27

<img width="2040" height="1222" alt="2026-27-onwards" src="https://github.com/user-attachments/assets/780a6a72-7941-428b-b652-d3cd45af701c" />

---


### Pre TY 2026-27
<img width="2038" height="1244" alt="pre-2026-27" src="https://github.com/user-attachments/assets/7778f91e-d5e4-4881-837f-f9d1a44dd439" />

